### PR TITLE
iio: bmi260: Adapt namespace API change

### DIFF
--- a/bmi260.h
+++ b/bmi260.h
@@ -2,6 +2,7 @@
 #ifndef BMI260_H_
 #define BMI260_H_
 
+#include <linux/version.h>
 #include <linux/iio/iio.h>
 #include <linux/regulator/consumer.h>
 
@@ -49,5 +50,13 @@ int bmi260_enable_irq(struct regmap *regmap, enum bmi260_int_pin pin, bool enabl
 int bmi260_probe_trigger(struct iio_dev *indio_dev, int irq, u32 irq_type);
 
 extern const struct dev_pm_ops bmi260_pm_ops;
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
+#define BMI260_EXPORT_SYMBOL(symbol)	EXPORT_SYMBOL_NS_GPL(symbol, "IIO_BMI260");
+#define BMI260_IMPORT_NS		MODULE_IMPORT_NS("IIO_BMI260");
+#else
+#define BMI260_EXPORT_SYMBOL(symbol)	EXPORT_SYMBOL_NS_GPL(symbol, IIO_BMI260);
+#define BMI260_IMPORT_NS		MODULE_IMPORT_NS(IIO_BMI260);
+#endif
 
 #endif  /* BMI260_H_ */

--- a/bmi260_core.c
+++ b/bmi260_core.c
@@ -141,7 +141,7 @@ const struct regmap_config bmi260_regmap_config = {
 	.reg_bits = 8,
 	.val_bits = 8,
 };
-EXPORT_SYMBOL_NS(bmi260_regmap_config, IIO_BMI260);
+BMI260_EXPORT_SYMBOL(bmi260_regmap_config);
 
 struct bmi260_regs {
 	u8 data; /* LSB byte register for X-axis */
@@ -683,7 +683,7 @@ int bmi260_enable_irq(struct regmap *regmap, enum bmi260_int_pin pin, bool enabl
 				     mask, enable_bit,
 				     BMI260_NORMAL_WRITE_USLEEP);
 }
-EXPORT_SYMBOL_NS(bmi260_enable_irq, IIO_BMI260);
+BMI260_EXPORT_SYMBOL(bmi260_enable_irq);
 
 static int bmi260_get_irq(struct fwnode_handle *fwnode, enum bmi260_int_pin *pin)
 {
@@ -986,7 +986,7 @@ int bmi260_core_probe(struct device *dev, struct regmap *regmap,
 
 	return devm_iio_device_register(dev, indio_dev);
 }
-EXPORT_SYMBOL_NS_GPL(bmi260_core_probe, IIO_BMI260);
+BMI260_EXPORT_SYMBOL(bmi260_core_probe);
 
 static int bmi260_chip_resume(struct device *dev) {
 	struct bmi260_data *data = iio_priv(dev_get_drvdata(dev));

--- a/bmi260_i2c.c
+++ b/bmi260_i2c.c
@@ -75,4 +75,4 @@ module_i2c_driver(bmi260_i2c_driver);
 MODULE_AUTHOR("Justin Weiss <justin@justinweiss.com>");
 MODULE_DESCRIPTION("BMI260 I2C driver");
 MODULE_LICENSE("GPL v2");
-MODULE_IMPORT_NS(IIO_BMI260);
+BMI260_IMPORT_NS;


### PR DESCRIPTION
Backport: https://github.com/justinweiss/bmi260/pull/2

Starting from commit cdd30ebb1b9f ("module: Convert symbol namespace to string literal"), namespace passed to EXPORT_SYMBOL_NS() API should be a string literal.

Adapt this change to fix compatbility with 6.13 and higher kernel.

Signed-off-by: Yao Zi <ziyao@disroot.org>
(cherry picked from commit 15f34aa2d4a74e13695dc44f9e1b1165d71cebfe)